### PR TITLE
Bugfix/remove dc relation for atla

### DIFF
--- a/app/mappings/bulkrax/oai_dc_mapping.rb
+++ b/app/mappings/bulkrax/oai_dc_mapping.rb
@@ -13,7 +13,8 @@ module Bulkrax
     matcher 'language', parsed: true, split: true
     matcher 'place', from: ['coverage']
     matcher 'publisher', split: /\s*[;]\s*/
-    matcher 'relation', split: true
+    # NOTE (dewey4iv): Commented out per Rob. Being removed temporarily for ATLA's use
+    # matcher 'relation', split: true
     matcher 'subject', split: true
     matcher 'title'
     matcher 'types', from: ['types', 'type'], split: true, parsed: true

--- a/app/mappings/bulkrax/oai_ptc_mapping.rb
+++ b/app/mappings/bulkrax/oai_ptc_mapping.rb
@@ -12,11 +12,11 @@ module Bulkrax
     matcher 'language', parsed: true, split: true
     matcher 'place', from: ['coverage']
     matcher 'publisher', split: /\s*[;]\s*/
-    matcher 'subject', split: true
-    matcher 'title'
-    matcher 'types', from: ['types', 'type'], split: true, parsed: true
     # NOTE (dewey4iv): Commented out per Rob. Being removed temporarily for ATLA's use
     # matcher 'relation', split: true
     matcher 'remote_files', from: ['thumbnail_url'], parsed: true
+    matcher 'subject', split: true
+    matcher 'title'
+    matcher 'types', from: ['types', 'type'], split: true, parsed: true
   end
 end

--- a/app/mappings/bulkrax/oai_ptc_mapping.rb
+++ b/app/mappings/bulkrax/oai_ptc_mapping.rb
@@ -15,7 +15,8 @@ module Bulkrax
     matcher 'subject', split: true
     matcher 'title'
     matcher 'types', from: ['types', 'type'], split: true, parsed: true
-    matcher 'relation', split: true
+    # NOTE (dewey4iv): Commented out per Rob. Being removed temporarily for ATLA's use
+    # matcher 'relation', split: true
     matcher 'remote_files', from: ['thumbnail_url'], parsed: true
   end
 end

--- a/app/mappings/bulkrax/oai_qualified_dc_mapping.rb
+++ b/app/mappings/bulkrax/oai_qualified_dc_mapping.rb
@@ -16,7 +16,8 @@ module Bulkrax
     matcher 'language', parsed: true, split: true
     matcher 'place', from: ['coverage', 'spatial']
     matcher 'publisher', split: /\s*[;]\s*/
-    matcher 'relation', split: true
+    # NOTE (dewey4iv): Commented out per Rob. Being removed temporarily for ATLA's use
+    # matcher 'relation', split: true
     matcher 'rights_holder', from: ['rights_holder', 'rightsHolder']
     matcher 'subject', split: true
     matcher 'time_period', from: ['time_period', 'temporal'], split: true

--- a/app/mappings/bulkrax/oai_qualified_dc_mapping.rb
+++ b/app/mappings/bulkrax/oai_qualified_dc_mapping.rb
@@ -18,11 +18,11 @@ module Bulkrax
     matcher 'publisher', split: /\s*[;]\s*/
     # NOTE (dewey4iv): Commented out per Rob. Being removed temporarily for ATLA's use
     # matcher 'relation', split: true
+    matcher 'remote_files', from: ['thumbnail_url'], parsed: true
     matcher 'rights_holder', from: ['rights_holder', 'rightsHolder']
     matcher 'subject', split: true
     matcher 'time_period', from: ['time_period', 'temporal'], split: true
     matcher 'title'
     matcher 'types', from: ['types', 'type'], split: true, parsed: true
-    matcher 'remote_files', from: ['thumbnail_url'], parsed: true
   end
 end


### PR DESCRIPTION
- Temporarily removes `relation` from all mappings.
- Reorders to match alpha order

Related to: https://gitlab.com/notch8/atla_digital_library/issues/100