### PR TITLE
Add a factory for collection and stub the call to Collection.where

### DIFF
--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :collection, class: 'Collection' do
+    id { 'collection_id' }
+    title { ['MyCollection'] }
+  end
+end

--- a/spec/features/oai_dc_importer_spec.rb
+++ b/spec/features/oai_dc_importer_spec.rb
@@ -2,16 +2,17 @@ require 'rails_helper'
 
 module Bulkrax
   RSpec.describe 'Importing an oai feed' do
-    let(:importer) {
+    let(:importer) do
       f = FactoryBot.build(:bulkrax_importer_oai)
       f.user = User.new(email: 'test@example.com')
       f.save
       f
-    }
+    end
+    let(:collection) { FactoryBot.build(:collection) }
 
     it 'should create a work' do
+      allow(Collection).to receive(:where).and_return([collection])
       importer.import_works
     end
   end
 end
-


### PR DESCRIPTION
Fixes #6 - prevent Solr connection by adding a factory for collection and stubbing the call to Collection.where in `oai_dc_importer_spec`.