### PR TITLE
Allow bulkrax engine to work correctly if you install migrations into…

### DIFF
--- a/lib/bulkrax/engine.rb
+++ b/lib/bulkrax/engine.rb
@@ -5,7 +5,7 @@ module Bulkrax
     isolate_namespace Bulkrax
     initializer :append_migrations do |app|
       if !app.root.to_s.match root.to_s &&
-         app.root.join('db/migrate').glob("*.bulkrax.rb").blank?
+         app.root.join('db/migrate').children.none? {|path| path.fnmatch?("*.bulkrax.rb")}
         config.paths["db/migrate"].expanded.each do |expanded_path|
           app.config.paths["db/migrate"] << expanded_path
         end

--- a/lib/bulkrax/engine.rb
+++ b/lib/bulkrax/engine.rb
@@ -4,7 +4,8 @@ module Bulkrax
   class Engine < ::Rails::Engine
     isolate_namespace Bulkrax
     initializer :append_migrations do |app|
-      unless app.root.to_s.match root.to_s
+      if !app.root.to_s.match root.to_s &&
+         app.root.join('db/migrate').glob("*.bulkrax.rb").blank?
         config.paths["db/migrate"].expanded.each do |expanded_path|
           app.config.paths["db/migrate"] << expanded_path
         end


### PR DESCRIPTION
… the base app

Though the recommended procedure is to leave migrations in the engine. This is because common practice in the Rails community does not match what's in the Rails guide.