### PR TITLE
Fix wrong argument type error with brackets

### DIFF
--- a/lib/bulkrax/engine.rb
+++ b/lib/bulkrax/engine.rb
@@ -4,8 +4,7 @@ module Bulkrax
   class Engine < ::Rails::Engine
     isolate_namespace Bulkrax
     initializer :append_migrations do |app|
-      if !app.root.to_s.match root.to_s &&
-         app.root.join('db/migrate').children.none? {|path| path.fnmatch?("*.bulkrax.rb")}
+      if !app.root.to_s.match(root.to_s) && app.root.join('db/migrate').children.none? {|path| path.fnmatch?("*.bulkrax.rb")}
         config.paths["db/migrate"].expanded.each do |expanded_path|
           app.config.paths["db/migrate"] << expanded_path
         end


### PR DESCRIPTION
With the latest change I'm getting `lib/bulkrax/engine.rb:7:in `match': wrong argument type true (expected Regexp) (TypeError)`

Wrapping the match input in brackets fixes it.