### PR TITLE
remove atla specific code

### DIFF
--- a/app/models/bulkrax/concerns/has_local_processing.rb
+++ b/app/models/bulkrax/concerns/has_local_processing.rb
@@ -1,0 +1,3 @@
+module Bulkrax::Concerns::HasLocalProcessing
+	def add_local; end
+end

--- a/app/models/bulkrax/concerns/has_local_processing.rb
+++ b/app/models/bulkrax/concerns/has_local_processing.rb
@@ -1,3 +1,3 @@
 module Bulkrax::Concerns::HasLocalProcessing
-	def add_local; end
+  def add_local; end
 end

--- a/app/models/bulkrax/csv_collection_entry.rb
+++ b/app/models/bulkrax/csv_collection_entry.rb
@@ -6,6 +6,8 @@ module Bulkrax
 
     def build_metadata
       self.parsed_metadata = self.raw_metadata
+      add_local
+      return self.parsed_metadata
     end
 
     def collections_created?

--- a/app/models/bulkrax/csv_entry.rb
+++ b/app/models/bulkrax/csv_entry.rb
@@ -7,6 +7,7 @@ module Bulkrax
 
     def build_metadata
       self.parsed_metadata = {}
+      self.parsed_metadata[Bulkrax.system_identifier_field] = [record['source_identifier']]
 
       if record.nil?
         raise StandardError, 'Record not found'
@@ -20,7 +21,7 @@ module Bulkrax
       add_visibility
       add_rights_statement
       add_collections
-      self.parsed_metadata[Bulkrax.system_identifier_field] ||= [record['source_identifier']]
+      add_local
 
       self.parsed_metadata
     end

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -1,6 +1,8 @@
 module Bulkrax
   class Entry < ApplicationRecord
     include Bulkrax::Concerns::HasMatchers
+    include Bulkrax::Concerns::HasLocalProcessing
+    
     belongs_to :importer
     serialize :parsed_metadata, JSON
     serialize :raw_metadata, JSON

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -16,10 +16,6 @@ module Bulkrax
       raw_record.record.header.set_spec
     end
 
-    def contributing_institution
-      parser.parser_fields['institution_name']
-    end
-
     def context
       @context ||= OpenStruct.new(record: record, identifier: record.header.identifier)
     end
@@ -30,6 +26,7 @@ module Bulkrax
 
     def build_metadata
       self.parsed_metadata = {}
+      self.parsed_metadata[Bulkrax.system_identifier_field] = [record.header.identifier]
 
       record.metadata.children.each do |child|
         child.children.each do |node|
@@ -38,12 +35,12 @@ module Bulkrax
       end
       add_metadata('thumbnail_url', thumbnail_url)
 
-      self.parsed_metadata[Bulkrax.system_identifier_field] ||= [record.header.identifier]
       self.parsed_metadata['contributing_institution'] = [contributing_institution]
 
       add_visibility
       add_rights_statement
       add_collections
+      add_local
 
       return self.parsed_metadata
     end

--- a/app/models/bulkrax/oai_set_entry.rb
+++ b/app/models/bulkrax/oai_set_entry.rb
@@ -6,6 +6,8 @@ module Bulkrax
 
     def build_metadata
       self.parsed_metadata = self.raw_metadata
+      add_local
+      return self.parsed_metadata
     end
 
     def collections_created?

--- a/app/parsers/bulkrax/application_parser.rb
+++ b/app/parsers/bulkrax/application_parser.rb
@@ -4,10 +4,6 @@ module Bulkrax
     attr_accessor :importer, :total
     delegate :only_updates, :limit, :current_importer_run, :seen, :increment_counters, :parser_fields, :user, to: :importer
 
-    def self.parser_fields
-      {}
-    end
-
     def initialize(importer)
       @importer = importer
     end

--- a/app/parsers/bulkrax/csv_parser.rb
+++ b/app/parsers/bulkrax/csv_parser.rb
@@ -2,14 +2,6 @@ module Bulkrax
   class CsvParser < ApplicationParser
     delegate :errors, :increment_counters, :parser_fields, to: :importer
 
-    def self.parser_fields
-      {
-        csv_path: :string,
-        rights_statements: :string,
-        override_rights_statement: :boolean
-      }
-    end
-
     def records(_opts = {})
       # there's a risk that this reads the whole file into memory and could cause a memory leak
       @records ||= CSV.foreach(

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -3,20 +3,6 @@ module Bulkrax
     attr_accessor :client, :headers
     delegate :list_sets, to: :client
 
-    def self.parser_fields
-      {
-        base_url: :string,
-        metadata_prefix: :string,
-        set: :string,
-        institution_name: :string,
-        rights_statements: :string,
-        override_rights_statement: :boolean,
-        # @todo remove once field_mapping and exclude are supported
-        blank_rights_statement: :boolean,
-        thumbnail_url: :string
-      }
-    end
-
     def initialize(importer)
       super
       @headers = { from: importer.user.email }

--- a/app/views/bulkrax/importers/_oai_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_fields.html.erb
@@ -5,8 +5,6 @@
   
   <%= fi.input :set, collection: [importer.parser_fields['set']], label: 'Set (source)', selected: importer.parser_fields['set'] %>
   <button type="button" class="btn btn-default refresh-set-source">Refresh Sets</button>
-
-  <%= fi.input :institution_name, as: :string, input_html: { value: importer.parser_fields['institution_name'] } %>
   
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement, required: false,


### PR DESCRIPTION
This PR removes ATLA specific code. An accompanying PR in ATLA will add the necessary code there.

It also:
* removes self.parser_fields from the parser - this doesn't appear to be used any more
* moves the identifier setting in the entry build to the top, I introduced a bug where the identifier was not being set (because of unnecessary cacheing).