### PR TITLE
Unique OAI set identifiers

### DIFF
--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -78,6 +78,11 @@ module Bulkrax
       parser.create_collections
     end
 
+    # Prepend the base_url to ensure unique set identifiers
+    def unique_collection_identifier(id)
+      "#{self.parser_fields['base_url'].split('/')[2]}_#{id}"
+    end
+
     def remove_unseen
       # TODO
       # if primary_collection

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -65,7 +65,7 @@ module Bulkrax
         self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
       else
         sets.each do |set|
-          c = Collection.where(Bulkrax.system_identifier_field => set.content).first
+          c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(set.content)).first
           self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
         end
       end

--- a/app/parsers/bulkrax/oai_dc_parser.rb
+++ b/app/parsers/bulkrax/oai_dc_parser.rb
@@ -80,11 +80,11 @@ module Bulkrax
 
       list_sets.each do |set|
         next unless collection_name == 'all' || collection_name == set.spec
-
+        unique_collection_identifier = importer.unique_collection_identifier(set.spec)
         metadata[:title] = [set.name]
-        metadata[Bulkrax.system_identifier_field] = [set.spec]
+        metadata[Bulkrax.system_identifier_field] = [unique_collection_identifier]
 
-        new_entry = collection_entry_class.where(importer: importer, identifier: set.spec, raw_metadata: metadata).first_or_create!
+        new_entry = collection_entry_class.where(importer: importer, identifier: unique_collection_identifier, raw_metadata: metadata).first_or_create!
         # perform now to ensure this gets created before work imports start
         ImportWorkCollectionJob.perform_now(new_entry.id, importer.current_importer_run.id)
       end


### PR DESCRIPTION
We can't guarantee the set spec identifier is globally unique, so prepend the collection system identifier with the base url to ensure uniqueness. 

