### PR TITLE
Fixes a bug in collections_created?

### DIFF
--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -49,8 +49,10 @@ module Bulkrax
     def collections_created?
       if sets.blank? || parser.collection_name != 'all'
         self.collection_ids.length == 1
+      elsif parser.collection_name == 'all'
+        sets.length == self.collection_ids.length
       else
-        sets.length == self.collection_ids.length  
+        self.collection_ids.length == 1
       end
     end
 


### PR DESCRIPTION
There was a bug in the logic of `Bulkrax::OaiEntry#collections_created?`. We were looking for sets.length to be the same as the length of collection_ids but if we are harvesting from only one set, but the record belongs to many in OAI, the logic breaks down. Instead, we should check for sets.length only when harvesting 'All', and otherwise look for one collection_id.

Whilst works can be in multiple collections, OAI entries should only have multiple collection_ids when running 'all'.