### PR TITLE
Colletions created bugfix(2)

### DIFF
--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -47,8 +47,9 @@ module Bulkrax
     end
 
     def collections_created?
+      
       if parser.collection_name == 'all'
-        sets.blank? || (sets.length == self.collection_ids.length)
+        sets.blank? || (sets.exist? && sets.length == self.collection_ids.length)
       else
         self.collection_ids.length == 1
       end

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -47,11 +47,10 @@ module Bulkrax
     end
 
     def collections_created?
-      
       if parser.collection_name == 'all'
-        sets.blank? || (sets.exist? && sets.length == self.collection_ids.length)
+        sets.blank? || (sets.present? && sets.size == self.collection_ids.size)
       else
-        self.collection_ids.length == 1
+        self.collection_ids.size == 1
       end
     end
 
@@ -63,10 +62,16 @@ module Bulkrax
 
       if sets.blank? || parser.collection_name != 'all'
         c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(parser.collection_name)).first
-        self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
+        if c.present? && !self.collection_ids.include?(c.id)
+          self.collection_ids << c.id
+        end
       else # All - collections should exist for all sets
-        c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(set.content)).first
-        self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
+        sets.each do |set|
+          c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(set.content)).first
+          if c.present? && !self.collection_ids.include?(c.id)
+            self.collection_ids << c.id
+          end
+        end
       end
       return self.collection_ids
     end

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -47,10 +47,8 @@ module Bulkrax
     end
 
     def collections_created?
-      if sets.blank? || parser.collection_name != 'all'
-        self.collection_ids.length == 1
-      elsif parser.collection_name == 'all'
-        sets.length == self.collection_ids.length
+      if parser.collection_name == 'all'
+        sets.blank? || (sets.length == self.collection_ids.length)
       else
         self.collection_ids.length == 1
       end
@@ -62,16 +60,13 @@ module Bulkrax
     def find_or_create_collection_ids
       return self.collection_ids if collections_created?
 
-      if sets.blank?
-        c = Collection.where(Bulkrax.system_identifier_field => parser.collection_name).first
+      if sets.blank? || parser.collection_name != 'all'
+        c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(parser.collection_name)).first
         self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
-      else
-        sets.each do |set|
-          c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(set.content)).first
-          self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
-        end
+      else # All - collections should exist for all sets
+        c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(set.content)).first
+        self.collection_ids << c.id unless c.blank? || self.collection_ids.include?(c.id)
       end
-      
       return self.collection_ids
     end
 

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -19,14 +19,14 @@ module Bulkrax
 
         it 'expects collections for all sets' do
           allow(entry).to receive_message_chain(:sets, :exist?).and_return(true)
-          allow(entry).to receive_message_chain(:sets, :length).and_return(5)
+          allow(entry).to receive_message_chain(:sets, :size).and_return(5)
           expect(entry.collections_created?).to be_falsey
         end
 
         it 'expects collections for all sets' do
           entry.collection_ids = [1, 2, 3, 4, 5]
           allow(entry).to receive_message_chain(:sets, :exist?).and_return(true)
-          allow(entry).to receive_message_chain(:sets, :length).and_return(5)
+          allow(entry).to receive_message_chain(:sets, :size).and_return(5)
           expect(entry.collections_created?).to be_truthy
         end
       end
@@ -63,7 +63,7 @@ module Bulkrax
         entry.find_or_create_collection_ids
         expect(entry.collection_ids.length).to eq(1)
       end
-      it 'fails if there is no collectin' do
+      it 'fails if there is no collection' do
         allow(Collection).to receive(:where).and_return([])
         entry.find_or_create_collection_ids
         expect(entry.collection_ids.length).to eq(0)

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+module Bulkrax
+  RSpec.describe OaiEntry, type: :model do
+    let(:entry) { described_class.new(importer: importer) }
+    let(:importer) { FactoryBot.build(:bulkrax_importer_oai) }
+    let(:collection) { FactoryBot.build(:collection) }
+
+    describe 'collections created' do
+      context 'All' do
+        before do
+          importer.parser_fields['set'] = 'all'
+        end
+
+        it 'expects 0 collections where sets are blank' do
+          allow(entry).to receive(:sets).and_return(nil)
+          expect(entry.collections_created?).to be_truthy
+        end
+
+        it 'expects collections for all sets' do
+          allow(entry).to receive_message_chain(:sets, :exist?).and_return(true)
+          allow(entry).to receive_message_chain(:sets, :length).and_return(5)
+          expect(entry.collections_created?).to be_falsey
+        end
+
+        it 'expects collections for all sets' do
+          entry.collection_ids = [1, 2, 3, 4, 5]
+          allow(entry).to receive_message_chain(:sets, :exist?).and_return(true)
+          allow(entry).to receive_message_chain(:sets, :length).and_return(5)
+          expect(entry.collections_created?).to be_truthy
+        end
+      end
+
+      context 'Single Set' do
+        before do
+          importer.parser_fields['set'] = 'some_set'
+        end
+
+        it 'expects only one collection - false if there are none' do
+          expect(entry.collections_created?).to be_falsey
+        end
+
+        it 'expects only one collection - false if there are more' do
+          entry.collection_ids = [1, 2]
+          expect(entry.collections_created?).to be_falsey
+        end
+
+        it 'expects only one collection' do
+          entry.collection_ids = [1]
+          expect(entry.collections_created?).to be_truthy
+        end
+      end
+    end
+
+    describe "find_or_create_collection_ids" do
+      before do
+        importer.parser_fields['set'] = 'some_set'
+        allow(entry).to receive_message_chain(:sets, :blank?).and_return(false)
+      end
+
+      it 'expects only one collection' do
+        allow(Collection).to receive(:where).and_return([collection])
+        entry.find_or_create_collection_ids
+        expect(entry.collection_ids.length).to eq(1)
+      end
+      it 'fails if there is no collectin' do
+        allow(Collection).to receive(:where).and_return([])
+        entry.find_or_create_collection_ids
+        expect(entry.collection_ids.length).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was still an issue with the logic, which should now be fixed:

* when a set is selected in the importer, ONE and only ONE collection is created, for that set
* entry.collection_ids will receive the identifier

* when 'all' is selected, a collection is created for ALL collections, if we can retrieve them from OAI for the record, in this case the entry.collection_ids will correspond to the number of sets

* when 'all' is selected, and we cannot retrieve sets from OAI for the record, no collections are created and entry.collection_ids will be 0