### PR TITLE
No more redudent jobs

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -135,12 +135,17 @@ module Bulkrax
 
     def new_remote_files
       @new_remote_files ||= if attributes[:remote_files].present? && object.present? && object.file_sets.present?
-                              attributes[:remote_files].reject do |file|
-                                existing = object.file_sets.detect { |f| f.import_url && f.import_url == file[:url] }
-                                existing
+                              attributes[:remote_files].select do |file|
+                                # is the url valid?
+                                is_valid = file[:url].match(URI::ABS_URI)
+                                # does the file already exist
+                                is_existing = object.file_sets.detect { |f| f.import_url && f.import_url == file[:url] }
+                                is_valid && !is_existing
                               end
                             elsif attributes[:remote_files].present?
-                              attributes[:remote_files]
+                              attributes[:remote_files].select do |file|
+                                file[:url].match(URI::ABS_URI)
+                              end
                             end
     end
 

--- a/app/jobs/bulkrax/import_work_job.rb
+++ b/app/jobs/bulkrax/import_work_job.rb
@@ -5,8 +5,11 @@ module Bulkrax
     def perform(*args)
       entry = Entry.find(args[0])
       begin
-        reschedule(entry.id, ImporterRun.find(args[1]).id) if entry.build.blank?
-        entry.save
+        if entry.build.present?
+          entry.save
+        else
+          reschedule(entry.id, ImporterRun.find(args[1]).id)
+        end
       rescue StandardError => e
         ImporterRun.find(args[1]).increment!(:failed_records)
         raise e


### PR DESCRIPTION
if a job does not build, it throws an exception during save, so it spawns jobs forever until there are millions of them.

![tribbles](https://fsmedia.imgix.net/ba/76/dd/f9/6348/4aff/b0b2/8720a3d5c0bc/screen-shot-2017-10-03-at-101624-ampng.png?rect=0%2C0%2C989%2C495&auto=format%2Ccompress&dpr=2&w=650)