### PR TITLE
Fix remote files parsing

### DIFF
--- a/app/factories/bulkrax/object_factory.rb
+++ b/app/factories/bulkrax/object_factory.rb
@@ -155,14 +155,14 @@ module Bulkrax
       @new_remote_files ||= if object.present? && object.file_sets.present?
                               parsed_remote_files.select do |file|
                                 # is the url valid?
-                                is_valid = file[:url].match(URI::ABS_URI)
+                                is_valid = file[:url]&.match(URI::ABS_URI)
                                 # does the file already exist
                                 is_existing = object.file_sets.detect { |f| f.import_url && f.import_url == file[:url] }
                                 is_valid && !is_existing
                               end
                             else
                               parsed_remote_files.select do |file|
-                                file[:url].match(URI::ABS_URI)
+                                file[:url]&.match(URI::ABS_URI)
                               end
                             end
     end

--- a/lib/bulkrax.rb
+++ b/lib/bulkrax.rb
@@ -57,6 +57,9 @@ module Bulkrax
         "resource_type" => { from: ["type"], parsed: true },
         "remote_files" => { from: ["thumbnail_url"], parsed: true }
       }
+      "Bulkrax::CsvParser" => {
+        "remote_files" => { from: ["remote_files"], parsed: true }
+      }
     }
 
     # Lambda to set the default field mapping


### PR DESCRIPTION
Remote files may not have :url set and would error out if they did not. this was actually the default for csv remote files, which I don't think actually uploaded?