### PR TITLE
Handle KeyError in Hyrax::ResourceTypesService

### DIFF
--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -66,6 +66,8 @@ module Bulkrax
     # Only add valid resource types
     def parse_resource_type(src)
       Hyrax::ResourceTypesService.label(src.to_s.strip.titleize)
+    rescue KeyError
+      nil
     end
 
     def parse_format_original(src)


### PR DESCRIPTION
Hyrax::ResourceTypesService throws a KeyError when the id isn't matched.

The resource types parser should return nil if a KeyError is raised.