### PR TITLE
Database and association changes for exporter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ PATH
       loofah (>= 2.2.3)
       oai (~> 0.4)
       rack (>= 2.0.6)
-      rails (~> 5.1.6)
-      simple_form (~> 3.2, <= 3.5.0)
+      rails (>= 5.1.6)
+      simple_form
 
 GEM
   remote: https://rubygems.org/

--- a/app/matchers/bulkrax/application_matcher.rb
+++ b/app/matchers/bulkrax/application_matcher.rb
@@ -66,6 +66,8 @@ module Bulkrax
     # Only add valid resource types
     def parse_resource_type(src)
       Hyrax::ResourceTypesService.label(src.to_s.strip.titleize)
+    rescue KeyError
+      nil
     end
 
     def parse_format_original(src)

--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -3,7 +3,12 @@ module Bulkrax
     include Bulkrax::Concerns::HasMatchers
     include Bulkrax::Concerns::HasLocalProcessing
 
-    belongs_to :importer
+    # @deprecated Please use importerexporter instead
+    #custom_deprecator = ActiveSupport::Deprecation.new('next-release', 'bulkrax')
+    #ActiveSupport::Deprecation.deprecate_methods(Bulkrax::Entry, importer: :importerexporter, deprecator: custom_deprecator)
+    belongs_to :importer, required: false
+    
+    belongs_to :importerexporter, polymorphic: true
     serialize :parsed_metadata, JSON
     # do not serialize raw_metadata as so we can support xml or other formats
     # keep it raw.
@@ -11,8 +16,7 @@ module Bulkrax
 
     attr_accessor :all_attrs, :last_exception
 
-    delegate :parser, :mapping,
-             to: :importer
+    delegate :parser, :mapping, to: :importerexporter
 
     delegate :client,
              :collection_name,

--- a/app/models/bulkrax/importer.rb
+++ b/app/models/bulkrax/importer.rb
@@ -7,7 +7,7 @@ module Bulkrax
 
     belongs_to :user
     has_many :importer_runs, dependent: :destroy, foreign_key: 'importer_id'
-    has_many :entries, dependent: :destroy, foreign_key: 'importer_id'
+    has_many :entries, as: :importerexporter, dependent: :destroy
 
     validates :name, presence: true
     validates :admin_set_id, presence: true

--- a/app/models/bulkrax/oai_entry.rb
+++ b/app/models/bulkrax/oai_entry.rb
@@ -59,13 +59,13 @@ module Bulkrax
       return self.collection_ids if collections_created?
 
       if sets.blank? || parser.collection_name != 'all'
-        c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(parser.collection_name)).first
+        c = Collection.where(Bulkrax.system_identifier_field => importerexporter.unique_collection_identifier(parser.collection_name)).first
         if c.present? && !self.collection_ids.include?(c.id)
           self.collection_ids << c.id
         end
       else # All - collections should exist for all sets
         sets.each do |set|
-          c = Collection.where(Bulkrax.system_identifier_field => importer.unique_collection_identifier(set.content)).first
+          c = Collection.where(Bulkrax.system_identifier_field => importerexporter.unique_collection_identifier(set.content)).first
           if c.present? && !self.collection_ids.include?(c.id)
             self.collection_ids << c.id
           end

--- a/bulkrax.gemspec
+++ b/bulkrax.gemspec
@@ -16,13 +16,13 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 5.1.6"
+  s.add_dependency "rails", ">= 5.1.6"
   s.add_dependency "loofah", ">= 2.2.3" # security issue, remove on rails upgrade
   s.add_dependency "rack", ">= 2.0.6" # security issue, remove on rails upgrade
+  s.add_dependency "simple_form"
   s.add_dependency 'iso8601', '~> 0.9.0'
   s.add_dependency 'oai', '~> 0.4'
   s.add_dependency 'libxml-ruby', '~> 3.1.0'
-  s.add_dependency 'simple_form', '~> 3.2', '<= 3.5.0'
   s.add_dependency 'language_list', '~> 1.2', '>= 1.2.1'
   s.add_development_dependency 'sqlite3', '~> 1.3.13'
   s.add_development_dependency 'simplecov'

--- a/db/migrate/20190729124607_create_bulkrax_exporters.rb
+++ b/db/migrate/20190729124607_create_bulkrax_exporters.rb
@@ -1,0 +1,17 @@
+class CreateBulkraxExporters < ActiveRecord::Migration[5.1]
+  def change
+    create_table :bulkrax_exporters do |t|
+      t.string :name
+      t.references :user, foreign_key: false
+      t.string :parser_klass
+      t.integer :limit
+      t.text :parser_fields
+      t.text :field_mapping
+      t.string :export_source
+      t.string :export_from
+      t.string :export_type
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190729134158_create_bulkrax_exporter_runs.rb
+++ b/db/migrate/20190729134158_create_bulkrax_exporter_runs.rb
@@ -1,0 +1,12 @@
+class CreateBulkraxExporterRuns < ActiveRecord::Migration[5.1]
+  def change
+    create_table :bulkrax_exporter_runs do |t|
+      t.references :exporter, foreign_key: { to_table: :bulkrax_exporters }
+      t.integer :total_records, default: 0
+      t.integer :enqueued_records, default: 0
+      t.integer :processed_records, default: 0
+      t.integer :deleted_records, default: 0
+      t.integer :failed_records, default: 0
+    end
+  end
+end

--- a/db/migrate/20190731114016_change_importer_and_exporter_to_polymorphic.rb
+++ b/db/migrate/20190731114016_change_importer_and_exporter_to_polymorphic.rb
@@ -1,0 +1,13 @@
+class ChangeImporterAndExporterToPolymorphic < ActiveRecord::Migration[5.1]
+  def change
+    add_column :bulkrax_entries, :importerexporter_id, :integer
+    add_column :bulkrax_entries, :importerexporter_type, :string, after: :id, default: 'Bulkrax::Importer'
+    
+    Bulkrax::Entry.reset_column_information
+    Bulkrax::Entry.includes(:importer).find_each do | entry |
+      entry.update_attribute(:importerexporter_id, entry.importer_id)
+    end
+
+    remove_column :bulkrax_entries, :importer_id
+  end
+end

--- a/spec/factories/bulkrax_entries.rb
+++ b/spec/factories/bulkrax_entries.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :bulkrax_entry, class: 'Bulkrax::Entry' do
     identifier { "MyString" }
     type { "" }
-    importer { nil }
+    importerexporter { nil }
     raw_metadata { "MyText" }
     parsed_metadata { "MyText" }
   end

--- a/spec/lib/bulkrax_spec.rb
+++ b/spec/lib/bulkrax_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Bulkrax do
 
     context 'field_mappings' do
       it 'has defaults for oaidc and qdc' do
-        expect(described_class.field_mappings.keys).to eq(["Bulkrax::OaiDcParser", "Bulkrax::OaiQualifiedDcParser"])
+        expect(described_class.field_mappings.keys).to eq(["Bulkrax::OaiDcParser", "Bulkrax::OaiQualifiedDcParser", "Bulkrax::CsvParser"])
       end
     end
   end

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -4,7 +4,7 @@ module Bulkrax
   RSpec.describe CsvEntry, type: :model do
     describe 'builds entry' do
       let(:importer) { FactoryBot.build(:bulkrax_importer_csv) }
-      subject { described_class.new(importer: importer) }
+      subject { described_class.new(importerexporter: importer) }
 
       context 'without required metadata' do
         before(:each) do
@@ -19,6 +19,11 @@ module Bulkrax
 
       context 'with required metadata' do
         before(:each) do
+          class WorkFactory < ObjectFactory
+            include WithAssociatedCollection
+            self.klass = Work
+            self.system_identifier_field = Bulkrax.system_identifier_field
+          end
           allow_any_instance_of(WorkFactory).to receive(:run)
           allow(subject).to receive(:record).and_return('source_identifier' => '2', 'title' => 'some title')
         end

--- a/spec/models/bulkrax/entry_spec.rb
+++ b/spec/models/bulkrax/entry_spec.rb
@@ -4,7 +4,7 @@ module Bulkrax
   RSpec.describe Entry, type: :model do
     describe 'field_mappings' do
       let(:importer) { FactoryBot.build(:bulkrax_importer) }
-      subject { described_class.new(importer: importer) }
+      subject { described_class.new(importerexporter: importer) }
 
       context '.mapping' do
 

--- a/spec/models/bulkrax/oai_entry_spec.rb
+++ b/spec/models/bulkrax/oai_entry_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 module Bulkrax
   RSpec.describe OaiEntry, type: :model do
-    let(:entry) { described_class.new(importer: importer) }
+    let(:entry) { described_class.new(importerexporter: importer) }
     let(:importer) { FactoryBot.build(:bulkrax_importer_oai) }
     let(:collection) { FactoryBot.build(:collection) }
 

--- a/spec/parsers/bulkrax/csv_parser_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_spec.rb
@@ -4,7 +4,7 @@ module Bulkrax
   RSpec.describe CsvParser do
     describe '#create_works' do
       let(:importer) { FactoryBot.create(:bulkrax_importer_csv) }
-      let(:entry) { FactoryBot.create(:bulkrax_entry, importer: importer) }
+      let(:entry) { FactoryBot.create(:bulkrax_entry, importerexporter: importer) }
       subject { described_class.new(importer) }
 
       before(:each) do
@@ -30,7 +30,7 @@ module Bulkrax
         end
 
         it 'skips all of the lines' do
-          expect(subject.importer).not_to receive(:increment_counters)
+          expect(subject.importerexporter).not_to receive(:increment_counters)
           subject.create_works
         end
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,7 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+  config.include Devise::TestHelpers, :type => :controller
 
   config.after(:each) do
     DatabaseCleaner.clean

--- a/spec/test_app/db/schema.rb
+++ b/spec/test_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190715162044) do
+ActiveRecord::Schema.define(version: 20190731114016) do
 
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 20190715162044) do
     t.string "identifier"
     t.string "collection_ids"
     t.string "type"
-    t.integer "importer_id"
     t.text "raw_metadata"
     t.text "parsed_metadata"
     t.datetime "created_at", null: false
@@ -36,7 +35,32 @@ ActiveRecord::Schema.define(version: 20190715162044) do
     t.text "last_error"
     t.datetime "last_error_at"
     t.datetime "last_succeeded_at"
-    t.index ["importer_id"], name: "index_bulkrax_entries_on_importer_id"
+    t.integer "importerexporter_id"
+    t.string "importerexporter_type", default: "Bulkrax::Importer"
+  end
+
+  create_table "bulkrax_exporter_runs", force: :cascade do |t|
+    t.integer "exporter_id"
+    t.integer "total_records", default: 0
+    t.integer "enqueued_records", default: 0
+    t.integer "processed_records", default: 0
+    t.integer "deleted_records", default: 0
+    t.integer "failed_records", default: 0
+    t.index ["exporter_id"], name: "index_bulkrax_exporter_runs_on_exporter_id"
+  end
+
+  create_table "bulkrax_exporters", force: :cascade do |t|
+    t.string "name"
+    t.integer "user_id"
+    t.string "parser_klass"
+    t.integer "limit"
+    t.text "field_mapping"
+    t.string "export_source"
+    t.string "export_from"
+    t.string "export_type"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_bulkrax_exporters_on_user_id"
   end
 
   create_table "bulkrax_importer_runs", force: :cascade do |t|


### PR DESCRIPTION
This PR adds migrations and changes to models / parser to make way for the exporter work.

When the new migrations are run, they should update existing `Bulkrax::Entry objects`, moving the `importer_id` to `importerexporter_id` before removing the `importer_id` column.

In addition:

* fix `spec/lib/bulkrax.rb`
* fix `spec/models/bulkrax/csv_entry_spec.rb`
* remove simple_form dependency; allow rails 5.2.* 