### PR TITLE
Remove deprecation of belongs_to: importer

### DIFF
--- a/app/models/bulkrax/entry.rb
+++ b/app/models/bulkrax/entry.rb
@@ -2,11 +2,6 @@ module Bulkrax
   class Entry < ApplicationRecord
     include Bulkrax::Concerns::HasMatchers
     include Bulkrax::Concerns::HasLocalProcessing
-
-    # @deprecated Please use importerexporter instead
-    #custom_deprecator = ActiveSupport::Deprecation.new('next-release', 'bulkrax')
-    #ActiveSupport::Deprecation.deprecate_methods(Bulkrax::Entry, importer: :importerexporter, deprecator: custom_deprecator)
-    belongs_to :importer, required: false
     
     belongs_to :importerexporter, polymorphic: true
     serialize :parsed_metadata, JSON

--- a/db/migrate/20190731114016_change_importer_and_exporter_to_polymorphic.rb
+++ b/db/migrate/20190731114016_change_importer_and_exporter_to_polymorphic.rb
@@ -1,3 +1,9 @@
+module Bulkrax
+  class Entry < ApplicationRecord
+     belongs_to :importer
+  end
+end
+
 class ChangeImporterAndExporterToPolymorphic < ActiveRecord::Migration[5.1]
   def change
     add_column :bulkrax_entries, :importerexporter_id, :integer


### PR DESCRIPTION
This PR removes the deprecatoin of `belongs_to: importer` from Bulkrax::Entry and adds it into the migration.